### PR TITLE
fixed bug for saved movie list items

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -192,6 +192,7 @@ function searchMovieByTitle(prevMovieName) {
   searchResultsH3.innerHTML = "";
   searchResultsList.innerHTML = "";
   imageDiv.innerHTML = "";
+  wikiDiv.innerHTML = "";
   console.log(prevMovieName);
   // if (prevMovieName !== PointerEvent || null) {
   //   var movieTitle = prevMovieName
@@ -318,6 +319,8 @@ function renderSavedMovies() {
 
     li.addEventListener("click", function (event) {
       var movieName = event.target.textContent;
+      console.log(movieName);
+      movieName = movieName.replace("Delete", "");
       console.log(movieName);
       searchMovieByTitle(movieName);
     });


### PR DESCRIPTION
Since we added the delete button to the saved movies list items, it changed the information being passed to the variable. I added a .replace method to delete the word "Delete" in the string so now the information passed in the variable is only the movie title. 